### PR TITLE
chore: fedora 42 is now end-of-life

### DIFF
--- a/check_fedora_iot.py
+++ b/check_fedora_iot.py
@@ -19,7 +19,7 @@ load_dotenv()
 # --- Configurations ---
 COMPOSE_BASE_URL = "https://kojipkgs.fedoraproject.org/compose/iot/"
 # TODO add a logic to get this version number based on GA or something.
-VERSIONS_TO_CHECK = ["45", "44", "43", "42"]
+VERSIONS_TO_CHECK = ["45", "44", "43"]
 REPOS_TO_SEARCH = ["osbuild/osbuild-composer", "osbuild/images"]
 RETRY_COUNT = 3
 RETRY_DELAY_SECONDS = 60


### PR DESCRIPTION
F42 is now EOL, drop from compose inspection.